### PR TITLE
Upgrade Prism & Add GoBack Support

### DIFF
--- a/directory.build.props
+++ b/directory.build.props
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<MauiVersion>8.0.14</MauiVersion>
+		<MauiVersion>8.0.20</MauiVersion>
 		<StandardTargetFramework>net8.0</StandardTargetFramework>
 	</PropertyGroup>
 

--- a/src/Moq.INavigationService/ExpressionExtension.cs
+++ b/src/Moq.INavigationService/ExpressionExtension.cs
@@ -23,7 +23,7 @@ internal static class ExpressionExtension
 			return default;
 		}
 	}
-	
+
 	public static string GetExpressionMethodName(this Expression expression)
 	{
 		var methodCall = (expression as LambdaExpression)?.Body as MethodCallExpression;

--- a/src/Moq.INavigationService/ExpressionExtension.cs
+++ b/src/Moq.INavigationService/ExpressionExtension.cs
@@ -23,4 +23,12 @@ internal static class ExpressionExtension
 			return default;
 		}
 	}
+	
+	public static string GetExpressionMethodName(this Expression expression)
+	{
+		var methodCall = (expression as LambdaExpression)?.Body as MethodCallExpression;
+		var methodName = methodCall?.Method.Name ?? throw new InvalidOperationException("Could not determine calling method name");
+
+		return methodName;
+	}
 }

--- a/src/Moq.INavigationService/MockNavigationService.cs
+++ b/src/Moq.INavigationService/MockNavigationService.cs
@@ -16,15 +16,9 @@ public class MockNavigationService : Mock<INavigationService>, INavigationServic
 	}
 
 	/// <inheritdoc />
-	public Task<INavigationResult> GoBackAsync(string viewName, INavigationParameters parameters)
+	public Task<INavigationResult> GoBackToAsync(string viewName, INavigationParameters parameters)
 	{
-		return Object.GoBackAsync(viewName, parameters);
-	}
-
-	/// <inheritdoc />
-	public Task<INavigationResult> GoBackToAsync(string name, INavigationParameters parameters)
-	{
-		return Object.GoBackToAsync(name, parameters);
+		return Object.GoBackToAsync(viewName, parameters);
 	}
 
 	/// <inheritdoc />
@@ -40,9 +34,9 @@ public class MockNavigationService : Mock<INavigationService>, INavigationServic
 	}
 
 	/// <inheritdoc />
-	public Task<INavigationResult> SelectTabAsync(string name, INavigationParameters parameters)
+	public Task<INavigationResult> SelectTabAsync(string name, Uri uri, INavigationParameters parameters)
 	{
-		return Object.SelectTabAsync(name, parameters);
+		return Object.SelectTabAsync(name, uri, parameters);
 	}
 
 	#endregion INavigationService

--- a/src/Moq.INavigationService/Moq.INavigationService.csproj
+++ b/src/Moq.INavigationService/Moq.INavigationService.csproj
@@ -37,7 +37,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Moq" Version="4.20.70"/>
-		<PackageReference Include="Prism.Maui" Version="9.0.401-pre"/>
+		<PackageReference Include="Prism.Maui" Version="9.0.537" />
 		<PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>

--- a/src/Moq.INavigationService/NavigationExpressionArgs.cs
+++ b/src/Moq.INavigationService/NavigationExpressionArgs.cs
@@ -19,11 +19,26 @@ internal class NavigationExpressionArgs
 		};
 	}
 
-	public static NavigationExpressionArgs FromUriExpression(Expression expression)
+	public static NavigationExpressionArgs FromNavigateUriExpression(Expression expression)
 	{
 		return new NavigationExpressionArgs
 		{
-			NavigationUri = GetNavigationUriFrom(expression),
+			NavigationUri = GetNavigationUriFrom(expression, 1),
+			NavigationParameters = ExpressionInspector.GetArgOf<NavigationParameters>(expression),
+		};
+	}
+
+	public static NavigationExpressionArgs FromGoBackToExpression(Expression expression)
+	{
+		var methodCall = (MethodCallExpression)((LambdaExpression)expression).Body;
+
+		var index = methodCall.Arguments.Any(a => a.Type == typeof(NavigationParameters))
+			? 0
+			: 1;
+
+		return new NavigationExpressionArgs
+		{
+			NavigationUri = GetNavigationUriFrom(expression, index),
 			NavigationParameters = ExpressionInspector.GetArgOf<NavigationParameters>(expression),
 		};
 	}
@@ -225,11 +240,11 @@ internal class NavigationExpressionArgs
 		return fieldValue;
 	}
 
-	private static Uri GetNavigationUriFrom(Expression expression)
+	private static Uri GetNavigationUriFrom(Expression expression, int index)
 	{
 		var methodCall = (MethodCallExpression)((LambdaExpression)expression).Body;
 
-		var destination = methodCall.Arguments[1];
+		var destination = methodCall.Arguments[index];
 
 		if (destination.Type == typeof(Uri))
 		{

--- a/src/Moq.INavigationService/SetupNavigationExtensions.cs
+++ b/src/Moq.INavigationService/SetupNavigationExtensions.cs
@@ -120,7 +120,7 @@ public static class SetupNavigationExtensions
 		GuardVerifyExpressionIsForNavigationExtensions(expression);
 
 		// Workout uri
-		var verifyNavigationExpression = VerifyNavigationExpression.From(expression);
+		var verifyNavigationExpression = VerifyNavigationExpression.FromNavigateExpression(expression);
 
 		return ApplySetup(
 			navigationServiceMock,

--- a/src/Moq.INavigationService/VerifyNavigationExpression.cs
+++ b/src/Moq.INavigationService/VerifyNavigationExpression.cs
@@ -8,18 +8,29 @@ internal class VerifyNavigationExpression
 	public required Expression? DestinationUriExpression { get; set; }
 	public required Expression? NavigationParametersExpression { get; set; }
 
-	public static VerifyNavigationExpression From(Expression expression)
+	public static VerifyNavigationExpression FromNavigateExpression(Expression expression)
 	{
 		return expression.ToString().Contains("CreateBuilder")
 			? ParseNavigationBuilderExpression(expression)
 			: ParseUriNavigationExpression(expression);
 	}
 
+	public static VerifyNavigationExpression FromGoBackToExpression(Expression expression)
+	{
+		return new VerifyNavigationExpression
+		{
+			Args = NavigationExpressionArgs.FromGoBackToExpression(expression),
+			DestinationStringExpression = ExpressionInspector.GetArgExpressionOf<string>(expression),
+			DestinationUriExpression = null,
+			NavigationParametersExpression = ExpressionInspector.GetArgExpressionOf<NavigationParameters>(expression),
+		};
+	}
+
 	private static VerifyNavigationExpression ParseUriNavigationExpression(Expression expression)
 	{
 		return new VerifyNavigationExpression
 		{
-			Args = NavigationExpressionArgs.FromUriExpression(expression),
+			Args = NavigationExpressionArgs.FromNavigateUriExpression(expression),
 			DestinationStringExpression = ExpressionInspector.GetArgExpressionOf<string>(expression),
 			DestinationUriExpression = ExpressionInspector.GetArgExpressionOf<Uri>(expression),
 			NavigationParametersExpression = ExpressionInspector.GetArgExpressionOf<NavigationParameters>(expression),

--- a/src/Moq.INavigationService/VerifyNavigationExtensions.cs
+++ b/src/Moq.INavigationService/VerifyNavigationExtensions.cs
@@ -140,11 +140,6 @@ public static class VerifyNavigationExtensions
 
 		try
 		{
-			if (expression.GetExpressionMethodName() == nameof(INavigationService.GoBackAsync))
-			{
-				navigationServiceMock.Verify(navigationService => navigationService.GoBackAsync(), timesFunc, failMessage);
-			}
-
 			var verifyNavigationExpression = VerifyNavigationExpression.FromNavigateExpression(expression);
 			var verifyExpression = CreateMoqVerifyNavigateAsyncExpressionFrom(verifyNavigationExpression);
 

--- a/src/Moq.INavigationService/VerifyNavigationExtensions.cs
+++ b/src/Moq.INavigationService/VerifyNavigationExtensions.cs
@@ -106,6 +106,11 @@ public static class VerifyNavigationExtensions
 				VerifyGoBack(navigationServiceMock, expression, times, timesFunc, failMessage);
 				break;
 			}
+
+			default:
+			{
+				throw new NotImplementedException("Method has no MockNavigation implementation.");
+			}
 		}
 
 

--- a/tests/Moq.INavigationService.Tests/Samples/SampleUriViewModel.cs
+++ b/tests/Moq.INavigationService.Tests/Samples/SampleUriViewModel.cs
@@ -100,4 +100,25 @@ public class SampleUriViewModel(INavigationService navigationService)
 	{
 		return await navigationService.GoBackToRootAsync();
 	}
+
+	public async Task<INavigationResult> GoBackWithParameters()
+	{
+		var navParams = new NavigationParameters() { { "KeyOne", "ValueOne" } };
+
+		return await navigationService.GoBackAsync(navParams);
+	}
+
+	public async Task<INavigationResult> GoBackToWithParameters()
+	{
+		var navParams = new NavigationParameters() { { "KeyOne", "ValueOne" } };
+
+		return await navigationService.GoBackToAsync("DestinationPage", navParams);
+	}
+
+	public async Task<INavigationResult> GoBackToRootWithParameters()
+	{
+		var navParams = new NavigationParameters() { { "KeyOne", "ValueOne" } };
+
+		return await navigationService.GoBackToRootAsync(navParams);
+	}
 }

--- a/tests/Moq.INavigationService.Tests/Samples/SampleUriViewModel.cs
+++ b/tests/Moq.INavigationService.Tests/Samples/SampleUriViewModel.cs
@@ -85,4 +85,19 @@ public class SampleUriViewModel(INavigationService navigationService)
 	{
 		return await navigationService.NavigateAsync("TabbedPage?createTab=NavigationPage|HomePage&createTab=NavigationPage|HelloPage");
 	}
+
+	public async Task<INavigationResult> GoBackWithNoParameters()
+	{
+		return await navigationService.GoBackAsync();
+	}
+
+	public async Task<INavigationResult> GoBackToWithNoParameters()
+	{
+		return await navigationService.GoBackToAsync("DestinationPage");
+	}
+
+	public async Task<INavigationResult> GoBackToRootWithNoParameters()
+	{
+		return await navigationService.GoBackToRootAsync();
+	}
 }

--- a/tests/Moq.INavigationService.Tests/VerifyUriViewModelTests.cs
+++ b/tests/Moq.INavigationService.Tests/VerifyUriViewModelTests.cs
@@ -165,5 +165,47 @@ public class VerifyUriViewModelTests : FixtureBase<SampleUriViewModel>
 		Assert.IsType<VerifyNavigationException>(ex);
 	}
 
+	[Fact]
+	public async Task Verify_GoBackWithNoParameters()
+	{
+		// Arrange
+
+		// Act
+		await Sut.GoBackWithNoParameters();
+
+		// Assert
+		navigationService.VerifyNavigation(
+			nav => nav.GoBackAsync(),
+			Times.Once());
+	}
+
+	[Fact]
+	public async Task Verify_GoBackToWithNoParameters()
+	{
+		// Arrange
+
+		// Act
+		await Sut.GoBackToWithNoParameters();
+
+		// Assert
+		navigationService.VerifyNavigation(
+			nav => nav.GoBackToAsync("DestinationPage"),
+			Times.Once());
+	}
+
+	[Fact]
+	public async Task Verify_GoBackToRootWithNoParameters()
+	{
+		// Arrange
+
+		// Act
+		await Sut.GoBackToRootWithNoParameters();
+
+		// Assert
+		navigationService.VerifyNavigation(
+			nav => nav.GoBackToRootAsync(),
+			Times.Once());
+	}
+
 	#endregion Tests
 }

--- a/tests/Moq.INavigationService.Tests/VerifyUriViewModelTests.cs
+++ b/tests/Moq.INavigationService.Tests/VerifyUriViewModelTests.cs
@@ -207,5 +207,53 @@ public class VerifyUriViewModelTests : FixtureBase<SampleUriViewModel>
 			Times.Once());
 	}
 
+	[Fact]
+	public async Task Verify_GoBackWithParameters()
+	{
+		// Arrange
+
+		// Act
+		await Sut.GoBackWithParameters();
+
+		// Assert
+		var expectedParams = new NavigationParameters() { { "KeyOne", "ValueOne" } };
+
+		navigationService.VerifyNavigation(
+			nav => nav.GoBackAsync(expectedParams),
+			Times.Once());
+	}
+
+	[Fact]
+	public async Task Verify_GoBackToWithParameters()
+	{
+		// Arrange
+
+		// Act
+		await Sut.GoBackToWithParameters();
+
+		// Assert
+		var expectedParams = new NavigationParameters() { { "KeyOne", "ValueOne" } };
+
+		navigationService.VerifyNavigation(
+			nav => nav.GoBackToAsync("DestinationPage", expectedParams),
+			Times.Once());
+	}
+
+	[Fact]
+	public async Task Verify_GoBackToRootWithParameters()
+	{
+		// Arrange
+
+		// Act
+		await Sut.GoBackToRootWithParameters();
+
+		// Assert
+		var expectedParams = new NavigationParameters() { { "KeyOne", "ValueOne" } };
+
+		navigationService.VerifyNavigation(
+			nav => nav.GoBackToRootAsync(expectedParams),
+			Times.Once());
+	}
+
 	#endregion Tests
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0",
+  "version": "1.1",
   "assemblyVersion": {
     "precision": "revision"
   },


### PR DESCRIPTION
This PR adds `VerifyNavigation` support to the following methods:

- `GoBackAsync`
- `GoBackToAsync`
- `GoBackToRootAsync`

This closes #8 and hopefully means the library is more usable to more people!

I have upgraded prism to the new stable version so this also has a version bump