### PR TITLE
Fixed Uri Navigation Verifications

### DIFF
--- a/.github/funding.yml
+++ b/.github/funding.yml
@@ -1,0 +1,2 @@
+github: axemasta
+buy_me_a_coffee: axemasta

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           global-json-file: global.json
+      - name: Install Maui Workloads
+        run: dotnet workload install maui --source https://api.nuget.org/v3/index.json
       - name: Restore dependencies
         run: dotnet restore
       - name: Build
@@ -50,6 +52,8 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         global-json-file: global.json
+    - name: Install Maui Workloads
+      run: dotnet workload install maui --source https://api.nuget.org/v3/index.json
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,6 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           global-json-file: global.json
-      - name: Install Maui Workloads
-        run: dotnet workload install maui --source https://api.nuget.org/v3/index.json
       - name: Restore dependencies
         run: dotnet restore
       - name: Build
@@ -52,8 +50,6 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         global-json-file: global.json
-    - name: Install Maui Workloads
-      run: dotnet workload install maui --source https://api.nuget.org/v3/index.json
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/directory.build.props
+++ b/directory.build.props
@@ -3,14 +3,4 @@
 		<EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
 		<SkipValidateMauiImplicitPackageReferences>true</SkipValidateMauiImplicitPackageReferences>
 	</PropertyGroup>
-
-	<PropertyGroup>
-		<MauiVersion>8.0.20</MauiVersion>
-		<StandardTargetFramework>net8.0</StandardTargetFramework>
-	</PropertyGroup>
-
-	<ItemGroup Condition=" $(UseMaui) == 'true' ">
-		<PackageVersion Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)"/>
-		<PackageVersion Include="Microsoft.Maui.Controls" Version="$(MauiVersion)"/>
-	</ItemGroup>
 </Project>

--- a/src/Moq.INavigationService/Moq.INavigationService.csproj
+++ b/src/Moq.INavigationService/Moq.INavigationService.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>$(StandardTargetFramework)</TargetFramework>
@@ -28,7 +28,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<InternalsVisibleTo Include="$(AssemblyName).Tests"/>
+		<InternalsVisibleTo Include="$(AssemblyName).Tests" />
 		<None Include="..\..\README.md">
 			<Pack>True</Pack>
 			<PackagePath>\</PackagePath>
@@ -36,13 +36,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Moq" Version="4.20.70"/>
+		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Prism.Maui" Version="9.0.537" />
-		<PackageReference Include="Nerdbank.GitVersioning" Version="3.6.133">
+		<PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="FluentAssertions" Version="6.12.0"/>
+		<PackageReference Include="FluentAssertions" Version="7.0.0" />
 	</ItemGroup>
 
 </Project>

--- a/src/Moq.INavigationService/Moq.INavigationService.csproj
+++ b/src/Moq.INavigationService/Moq.INavigationService.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>$(StandardTargetFramework)</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<UseMaui>true</UseMaui>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 	</PropertyGroup>
 

--- a/src/Moq.INavigationService/NavigationExpressionArgs.cs
+++ b/src/Moq.INavigationService/NavigationExpressionArgs.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Linq.Expressions;
 using System.Reflection;
+using Prism.Common;
 using Prism.Navigation.Builder;
 namespace Moq;
 
@@ -21,9 +23,20 @@ internal class NavigationExpressionArgs
 
 	public static NavigationExpressionArgs FromNavigateUriExpression(Expression expression)
 	{
+		var methodCall = (MethodCallExpression)((LambdaExpression)expression).Body;
+
+		if (methodCall.Arguments.Count == 0)
+		{
+			throw new InvalidOperationException("The method call does not have any arguments, cannot parse navigation expression.");
+		}
+
+		var firstArgumentIsNavigationService = methodCall.Arguments[0].Type == typeof(INavigationService);
+
+		var index = firstArgumentIsNavigationService ? 1 : 0;
+
 		return new NavigationExpressionArgs
 		{
-			NavigationUri = GetNavigationUriFrom(expression, 1),
+			NavigationUri = GetNavigationUriFrom(expression, index),
 			NavigationParameters = ExpressionInspector.GetArgOf<NavigationParameters>(expression),
 		};
 	}
@@ -255,12 +268,7 @@ internal class NavigationExpressionArgs
 		{
 			var destinationString = ExpressionInspector.GetArgOf<string>(expression);
 
-			if (Uri.TryCreate(destinationString, UriKind.RelativeOrAbsolute, out var destinationUri))
-			{
-				return destinationUri;
-			}
-
-			throw new NotSupportedException($"Could not parse destination string as uri: {destinationString}");
+			return UriParsingHelper.Parse(destinationString);
 		}
 
 		throw new NotSupportedException("Could not determine navigation destination from expression");

--- a/src/Moq.INavigationService/NavigationExpressionArgs.cs
+++ b/src/Moq.INavigationService/NavigationExpressionArgs.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq.Expressions;
 using System.Reflection;
 using Prism.Common;

--- a/tests/Moq.INavigationService.Tests/Moq.INavigationService.Tests.csproj
+++ b/tests/Moq.INavigationService.Tests/Moq.INavigationService.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<TargetFramework>$(StandardTargetFramework)</TargetFramework>
@@ -7,26 +7,25 @@
 		<UseMaui>true</UseMaui>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
-		<NoWarn>IDE0005</NoWarn>
+		<NoWarn>IDE0005;xUnit1045</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0"/>
-		<PackageReference Include="xunit" Version="2.7.0"/>
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="coverlet.collector" Version="6.0.2">
+		<PackageReference Include="coverlet.collector" Version="6.0.4">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="FluentAssertions" Version="6.12.0"/>
-		<PackageReference Include="Moq" Version="4.20.70"/>
+		<PackageReference Include="Moq" Version="4.20.72" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\..\src\Moq.INavigationService\Moq.INavigationService.csproj"/>
+		<ProjectReference Include="..\..\src\Moq.INavigationService\Moq.INavigationService.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/tests/Moq.INavigationService.Tests/Moq.INavigationService.Tests.csproj
+++ b/tests/Moq.INavigationService.Tests/Moq.INavigationService.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>$(StandardTargetFramework)</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
-		<UseMaui>true</UseMaui>
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
 		<NoWarn>IDE0005;xUnit1045</NoWarn>

--- a/tests/Moq.INavigationService.Tests/Samples/SampleUriViewModel.cs
+++ b/tests/Moq.INavigationService.Tests/Samples/SampleUriViewModel.cs
@@ -13,6 +13,40 @@ public class SampleUriViewModel(INavigationService navigationService)
 		return await navigationService.NavigateAsync("HomePage");
 	}
 
+	public async Task<INavigationResult> NavigateToAbsoluteHomePage()
+	{
+		return await navigationService.NavigateAsync("/NavigationPage/HomePage");
+	}
+
+	public async Task<INavigationResult> NavigateToAbsoluteHomePageViaUri()
+	{
+		var uri = new Uri("/NavigationPage/HomePage", UriKind.Relative);
+
+		return await navigationService.NavigateAsync(uri);
+	}
+
+	public async Task<INavigationResult> NavigateToAbsoluteHomePageWithParameters()
+	{
+		var navParams = new NavigationParameters()
+		{
+			{ "Name", "Glork" },
+		};
+
+		return await navigationService.NavigateAsync("/NavigationPage/HomePage", navParams);
+	}
+
+	public async Task<INavigationResult> NavigateToAbsoluteHomePageViaUriWithParameters()
+	{
+		var uri = new Uri("/NavigationPage/HomePage", UriKind.Relative);
+
+		var navParams = new NavigationParameters()
+		{
+			{ "Name", "Glork" },
+		};
+
+		return await navigationService.NavigateAsync(uri, navParams);
+	}
+
 	public async Task<INavigationResult> NavigateToHomePageViaUri()
 	{
 		var uri = new Uri("HomePage", UriKind.Relative);

--- a/tests/Moq.INavigationService.Tests/SetupUriViewModelTests.cs
+++ b/tests/Moq.INavigationService.Tests/SetupUriViewModelTests.cs
@@ -222,5 +222,70 @@ public class SetupUriViewModelTests : FixtureBase<SampleUriViewModel>
 		Assert.Null(result);
 	}
 
+	[Fact]
+	public async Task Verify_NavigateToAbsoluteHomePage()
+	{
+		// Arrange
+		navigationService.SetupNavigation(nav => nav.NavigateAsync("/NavigationPage/HomePage"));
+
+		// Act
+		await Sut.NavigateToAbsoluteHomePage();
+
+		// Assert
+		navigationService.Verify();
+	}
+
+	[Fact]
+	public async Task Verify_NavigateToAbsoluteHomePageViaUri()
+	{
+		// Arrange
+		var expectedUri = new Uri("/NavigationPage/HomePage", UriKind.Relative);
+
+		navigationService.SetupNavigation(nav => nav.NavigateAsync(expectedUri));
+
+		// Act
+		await Sut.NavigateToAbsoluteHomePageViaUri();
+
+		// Assert
+		navigationService.Verify();
+	}
+
+	[Fact]
+	public async Task Verify_NavigateToAbsoluteHomePageWithParameters()
+	{
+		// Arrange
+		var expectedParams = new NavigationParameters()
+		{
+			{ "Name", "Glork" },
+		};
+
+		navigationService.SetupNavigation(nav => nav.NavigateAsync("/NavigationPage/HomePage", expectedParams));
+
+		// Act
+		await Sut.NavigateToAbsoluteHomePageWithParameters();
+
+		// Assert
+		navigationService.Verify();
+	}
+
+	[Fact]
+	public async Task Verify_NavigateToAbsoluteHomePageViaUriWithParameters()
+	{
+		// Arrange
+		var expectedUri = new Uri("/NavigationPage/HomePage", UriKind.Relative);
+		var expectedParams = new NavigationParameters()
+		{
+			{ "Name", "Glork" },
+		};
+
+		navigationService.SetupNavigation(nav => nav.NavigateAsync(expectedUri, expectedParams));
+
+		// Act
+		await Sut.NavigateToAbsoluteHomePageViaUriWithParameters();
+
+		// Assert
+		navigationService.Verify();
+	}
+
 	#endregion Tests
 }

--- a/tests/Moq.INavigationService.Tests/VerifyUriViewModelTests.cs
+++ b/tests/Moq.INavigationService.Tests/VerifyUriViewModelTests.cs
@@ -255,5 +255,74 @@ public class VerifyUriViewModelTests : FixtureBase<SampleUriViewModel>
 			Times.Once());
 	}
 
+	[Fact]
+	public async Task Verify_NavigateToAbsoluteHomePage()
+	{
+		// Arrange
+
+		// Act
+		await Sut.NavigateToAbsoluteHomePage();
+
+		// Assert
+		navigationService.VerifyNavigation(
+			nav => nav.NavigateAsync("/NavigationPage/HomePage"),
+			Times.Once());
+	}
+
+	[Fact]
+	public async Task Verify_NavigateToAbsoluteHomePageViaUri()
+	{
+		// Arrange
+
+		// Act
+		await Sut.NavigateToAbsoluteHomePageViaUri();
+
+		// Assert
+		var expectedUri = new Uri("/NavigationPage/HomePage", UriKind.Relative);
+
+		navigationService.VerifyNavigation(
+			nav => nav.NavigateAsync(expectedUri),
+			Times.Once());
+	}
+
+	[Fact]
+	public async Task Verify_NavigateToAbsoluteHomePageWithParameters()
+	{
+		// Arrange
+
+		// Act
+		await Sut.NavigateToAbsoluteHomePageWithParameters();
+
+		// Assert
+		var expectedParams = new NavigationParameters()
+		{
+			{ "Name", "Glork" },
+		};
+
+		navigationService.VerifyNavigation(
+			nav => nav.NavigateAsync("/NavigationPage/HomePage", expectedParams),
+			Times.Once());
+	}
+
+	[Fact]
+	public async Task Verify_NavigateToAbsoluteHomePageViaUriWithParameters()
+	{
+		// Arrange
+
+		// Act
+		await Sut.NavigateToAbsoluteHomePageViaUriWithParameters();
+
+		// Assert
+		var expectedUri = new Uri("/NavigationPage/HomePage", UriKind.Relative);
+		var expectedParams = new NavigationParameters()
+		{
+			{ "Name", "Glork" },
+		};
+
+		navigationService.VerifyNavigation(
+			nav => nav.NavigateAsync(expectedUri, expectedParams),
+			Times.Once());
+	}
+
 	#endregion Tests
 }


### PR DESCRIPTION
Fixed the uri navigation verification failing when trying to verify absolute navigations (#11, #12)

The underlying issue was the same for both issues, related to how the navigation path to verify was being pulled from the expression when using uri based navigation. If using the non extension methods, it would expect the navigation destination in the wrong argument and subsequently throw an exception internally.

I've added test cases for all of the failing navigations and they are now all satisfied.

Thanks to @MiloszKowalski for raising #12 with a very detailed account of what was happening, it made it very easy to track down the issue and solve!

This pr also makes the following changes:

- Update nuget packages
- Remove dependencies on Maui Controls & Compatibility libraries since they have been unused for a few versions now