### PR TITLE
Remove Xunit Dependency From Library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,11 @@ jobs:
       VERSION_NAME: 0.0.1
       ARTIFACT_NAME: 'drop'
       ARTIFACTS: 'Artifacts/**/*.nupkg'
+
+    permissions:
+      id-token: write 
+      contents: write
+
     steps:
     - uses: actions/checkout@v3
 
@@ -144,8 +149,12 @@ jobs:
         prerelease: ${{ env.IS_PRERELEASE }}
         body: "TODO"
 
-    # Nuget will automatically pick up the symbol packages if they are in the same location as the main package
+    - name: NuGet login (OIDC - temp API key)
+      uses: NuGet/login@v1
+      id: login
+      with:
+        user: Axemasta
+
     - name: Publish NuGet
-      run: dotnet nuget push ${{ env.ARTIFACTS }} --source 'https://api.nuget.org/v3/index.json' --api-key ${{ secrets.NUGET_API_KEY }} --skip-duplicate
-
-
+      run: |
+        dotnet nuget push ${{ env.ARTIFACTS }} --source 'https://api.nuget.org/v3/index.json' --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" --skip-duplicate

--- a/src/Moq.INavigationService/EquivalenceHelper.cs
+++ b/src/Moq.INavigationService/EquivalenceHelper.cs
@@ -1,19 +1,13 @@
-using Xunit;
+using KellermanSoftware.CompareNetObjects;
 
 namespace Moq;
 
-internal class EquivalenceHelper
+internal sealed class EquivalenceHelper
 {
+	private static readonly CompareLogic CompareLogic = new();
+
 	public static bool AreEquivalent(object? a, object? b)
 	{
-		try
-		{
-			Assert.Equivalent(a, b);
-			return true;
-		}
-		catch
-		{
-			return false;
-		}
+		return CompareLogic.Compare(a, b).AreEqual;
 	}
 }

--- a/src/Moq.INavigationService/Moq.INavigationService.csproj
+++ b/src/Moq.INavigationService/Moq.INavigationService.csproj
@@ -38,13 +38,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="CompareNETObjects" Version="4.84.0" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Prism.Maui" Version="9.0.537" />
 		<PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="xunit" Version="2.9.3" PrivateAssets="All"/>
 	</ItemGroup>
 
 </Project>

--- a/tests/Moq.INavigationService.Tests/EquivalenceHelperTests.cs
+++ b/tests/Moq.INavigationService.Tests/EquivalenceHelperTests.cs
@@ -1,19 +1,16 @@
-using Xunit.Abstractions;
-namespace Moq.Tests;
+namespace Moq.INavigationServiceTests;
 
 public class EquivalenceHelperTests(ITestOutputHelper testOutputHelper)
 {
-	private readonly ITestOutputHelper testOutput = testOutputHelper;
-
 	[Theory]
 	[MemberData(nameof(EqualsTestData))]
 	public void AreEquivalent_Should_DetermineCorrectly(object? a, object? b, bool expectedEquivalent)
 	{
 		// Arrange
-		testOutput.WriteLine("Called with params:");
-		testOutput.WriteLine($"ParameterA: {a}");
-		testOutput.WriteLine($"ParameterB: {b}");
-		testOutput.WriteLine($"ExpectedEquivalent: {expectedEquivalent}");
+		testOutputHelper.WriteLine("Called with params:");
+		testOutputHelper.WriteLine($"ParameterA: {a}");
+		testOutputHelper.WriteLine($"ParameterB: {b}");
+		testOutputHelper.WriteLine($"ExpectedEquivalent: {expectedEquivalent}");
 
 		// Act
 		var equivalent = EquivalenceHelper.AreEquivalent(a, b);

--- a/tests/Moq.INavigationService.Tests/Moq.INavigationService.Tests.csproj
+++ b/tests/Moq.INavigationService.Tests/Moq.INavigationService.Tests.csproj
@@ -7,11 +7,12 @@
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
 		<NoWarn>IDE0005;xUnit1045</NoWarn>
+		<RootNamespace>Moq.INavigationServiceTests</RootNamespace>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-		<PackageReference Include="xunit" Version="2.9.3" />
+		<PackageReference Include="xunit.v3" Version="3.2.2" />
 		<PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>

--- a/tests/Moq.INavigationService.Tests/Properties/GlobalUsings.cs
+++ b/tests/Moq.INavigationService.Tests/Properties/GlobalUsings.cs
@@ -1,3 +1,3 @@
-global using Moq.Tests.TestHelpers;
+global using Moq.INavigationServiceTests.TestHelpers;
 global using Prism.Navigation;
 global using Xunit;

--- a/tests/Moq.INavigationService.Tests/Samples/SampleBuilderViewModel.cs
+++ b/tests/Moq.INavigationService.Tests/Samples/SampleBuilderViewModel.cs
@@ -1,4 +1,5 @@
-using Moq.Tests.Samples;
+using Moq.INavigationServiceTests.Samples;
+
 namespace Moq.Tests;
 
 /*
@@ -7,8 +8,6 @@ namespace Moq.Tests;
 
 public class SampleBuilderViewModel(INavigationService navigationService)
 {
-	private readonly INavigationService navigationService = navigationService;
-
 	public async Task<INavigationResult> NavigateToHomePage()
 	{
 		return await navigationService.CreateBuilder()

--- a/tests/Moq.INavigationService.Tests/Samples/SamplePages.cs
+++ b/tests/Moq.INavigationService.Tests/Samples/SamplePages.cs
@@ -1,4 +1,4 @@
-namespace Moq.Tests.Samples;
+namespace Moq.INavigationServiceTests.Samples;
 
 public class HomePage : ContentPage
 {

--- a/tests/Moq.INavigationService.Tests/Samples/SampleUriViewModel.cs
+++ b/tests/Moq.INavigationService.Tests/Samples/SampleUriViewModel.cs
@@ -1,4 +1,4 @@
-namespace Moq.Tests.Samples;
+namespace Moq.INavigationServiceTests.Samples;
 
 /*
 * Test viewmodel using the uri based navigation api

--- a/tests/Moq.INavigationService.Tests/SetupBuilderViewModelTests.cs
+++ b/tests/Moq.INavigationService.Tests/SetupBuilderViewModelTests.cs
@@ -1,16 +1,13 @@
-using Moq.Tests.Samples;
-namespace Moq.Tests;
+using Moq.INavigationServiceTests.Samples;
+using Moq.Tests;
+
+namespace Moq.INavigationServiceTests;
 
 public class SetupBuilderViewModelTests : FixtureBase<SampleBuilderViewModel>
 {
 	#region Setup
 
-	private readonly MockNavigationService navigationService;
-
-	public SetupBuilderViewModelTests()
-	{
-		navigationService = new MockNavigationService();
-	}
+	private readonly MockNavigationService navigationService = new();
 
 	public override SampleBuilderViewModel CreateSystemUnderTest()
 	{

--- a/tests/Moq.INavigationService.Tests/SetupNavigationExtensionTests.cs
+++ b/tests/Moq.INavigationService.Tests/SetupNavigationExtensionTests.cs
@@ -1,13 +1,8 @@
-namespace Moq.Tests;
+namespace Moq.INavigationServiceTests;
 
 public class SetupNavigationExtensionTests
 {
-	private readonly MockNavigationService navigationService;
-
-	public SetupNavigationExtensionTests()
-	{
-		navigationService = new MockNavigationService();
-	}
+	private readonly MockNavigationService navigationService = new();
 
 	[Fact]
 	public async Task SetupAllNavigationReturns_Should_MakeAllNavigationCallsReturnValue()

--- a/tests/Moq.INavigationService.Tests/SetupUriViewModelTests.cs
+++ b/tests/Moq.INavigationService.Tests/SetupUriViewModelTests.cs
@@ -1,5 +1,6 @@
-using Moq.Tests.Samples;
-namespace Moq.Tests;
+using Moq.INavigationServiceTests.Samples;
+
+namespace Moq.INavigationServiceTests;
 
 public class SetupUriViewModelTests : FixtureBase<SampleUriViewModel>
 {

--- a/tests/Moq.INavigationService.Tests/TestHelpers/FixtureBase.cs
+++ b/tests/Moq.INavigationService.Tests/TestHelpers/FixtureBase.cs
@@ -1,4 +1,4 @@
-namespace Moq.Tests.TestHelpers;
+namespace Moq.INavigationServiceTests.TestHelpers;
 
 public abstract class FixtureBase<TSut>
 {

--- a/tests/Moq.INavigationService.Tests/VerifyBuilderViewModelTests.cs
+++ b/tests/Moq.INavigationService.Tests/VerifyBuilderViewModelTests.cs
@@ -1,5 +1,7 @@
-using Moq.Tests.Samples;
-namespace Moq.Tests;
+using Moq.INavigationServiceTests.Samples;
+using Moq.Tests;
+
+namespace Moq.INavigationServiceTests;
 
 public class VerifyBuilderViewModelTests : FixtureBase<SampleBuilderViewModel>
 {

--- a/tests/Moq.INavigationService.Tests/VerifyUriViewModelTests.cs
+++ b/tests/Moq.INavigationService.Tests/VerifyUriViewModelTests.cs
@@ -1,16 +1,11 @@
-using Moq.Tests.Samples;
-namespace Moq.Tests;
+using Moq.INavigationServiceTests.Samples;
+namespace Moq.INavigationServiceTests;
 
 public class VerifyUriViewModelTests : FixtureBase<SampleUriViewModel>
 {
 	#region Setup
 
-	private readonly MockNavigationService navigationService;
-
-	public VerifyUriViewModelTests()
-	{
-		navigationService = new MockNavigationService();
-	}
+	private readonly MockNavigationService navigationService = new();
 
 	public override SampleUriViewModel CreateSystemUnderTest()
 	{


### PR DESCRIPTION
The library depended on xunit v2 for equivalnce checking. I've replaced it with [Compare Net Objects](https://github.com/GregFinzer/Compare-Net-Objects) instead, this is a public dependency and will allow consumers to use this library when targetting either xunit v2 or v3, they won't be forced to install xunit 2.9.3 even if they've moved to v3!

Updated the project unit tests namespace since xunit v3 was generating a namespace of `INavigationService` causing conflicts with prism.

Updated the build pipelines to use trusted nuget publishing